### PR TITLE
Fix datetimes in server trade router to always be UTC

### DIFF
--- a/app/src/TradePage/OpenPositions/index.tsx
+++ b/app/src/TradePage/OpenPositions/index.tsx
@@ -90,6 +90,7 @@ export const OpenPositions = ({ openPositions, lastUpdated }: Props) => {
                         year: 'numeric',
                         month: 'long',
                         day: '2-digit',
+                        timeZone: 'America/New_York',
                       }).format(openPosition.expiry)}
                   </td>
                   <td>{openPosition.markPrice.toFixed(2)}</td>

--- a/app/src/TradePage/TradeHistory/index.tsx
+++ b/app/src/TradePage/TradeHistory/index.tsx
@@ -84,6 +84,7 @@ export const TradeHistory = ({ trades, lastUpdated, timezone }: Props) => (
                     year: 'numeric',
                     month: 'long',
                     day: '2-digit',
+                    timeZone: 'America/New_York',
                   }).format(trade.expiry)}
               </td>
               <td>{trade.tradePrice.toFixed(2)}</td>

--- a/server/src/routes/TradesRouter/types.ts
+++ b/server/src/routes/TradesRouter/types.ts
@@ -136,6 +136,15 @@ export type TransformLast365CalendarDaysDataProps = {
   json: FlexQueryResponseType;
 };
 
+export type NullableDataToFlatArrayProps = {
+  data: any;
+};
+
+export type ConvertDateFromNewYorkTzToLocalProps = {
+  date: string;
+  format: string;
+};
+
 export type ConfigType = {
   token: string;
   Last365CalendarDaysFlexQueryId: string;

--- a/server/src/routes/TradesRouter/utils.ts
+++ b/server/src/routes/TradesRouter/utils.ts
@@ -1,0 +1,15 @@
+import moment from 'moment';
+import 'moment-timezone';
+
+import type { NullableDataToFlatArrayProps, ConvertDateFromNewYorkTzToLocalProps } from './types';
+
+export const nullableDataToFlatArray = ({ data }: NullableDataToFlatArrayProps): any => {
+  return data ? [data].flat() : [];
+};
+
+export const convertDateFromNewYorkTzToLocal = ({
+  date,
+  format,
+}: ConvertDateFromNewYorkTzToLocalProps): moment.Moment => {
+  return moment.tz(date, format, 'America/New_York');
+};


### PR DESCRIPTION
Some of datetimes were not in UTC and time view return chart was essentially showing 2 July - date (with New York times). This fix makes every datetime UTC at API level.