### PR TITLE
Payload: Use depth of 1 (Fixes #158)

### DIFF
--- a/app/src/app/(frontend)/api/custom/posts/[postId]/comments/route.ts
+++ b/app/src/app/(frontend)/api/custom/posts/[postId]/comments/route.ts
@@ -4,8 +4,6 @@ import config from '@payload-config';
 import { mapComments } from '@/utils/payload';
 import { CommentsForPost } from '@/types/api/commentsForPost';
 
-const depth = 2;
-
 export const GET = async (request: Request, { params: paramsPromise }: { params: Promise<{ postId: string }> }) => {
   try {
     const params = await paramsPromise;
@@ -21,7 +19,7 @@ export const GET = async (request: Request, { params: paramsPromise }: { params:
       where: {
         post: { equals: postId },
       },
-      depth,
+      depth: 1,
       limit: 0,
       pagination: false,
     });

--- a/app/src/app/(frontend)/api/custom/resume/route.ts
+++ b/app/src/app/(frontend)/api/custom/resume/route.ts
@@ -8,7 +8,6 @@ import { Users } from '@payload/collections/Users';
 import { ResumeRequest } from '@/types/api/resume';
 import { ErrorResonse } from '@/types/api/error';
 
-const depth = 2;
 const systemUserApiKey = requireEnvVar(process.env.PAYLOAD_SYSTEM_USER_API_KEY, 'PAYLOAD_SYSTEM_USER_API_KEY');
 
 export const POST = async (request: Request) => {
@@ -22,7 +21,7 @@ export const POST = async (request: Request) => {
 
     const resumeGlobal = await payload.findGlobal({
       slug: 'resume',
-      depth,
+      depth: 1,
     });
 
     const validPasswords = resumeGlobal.passwords?.map((entry) => entry.password) || [];

--- a/app/src/app/(frontend)/blog/[...slug]/page.tsx
+++ b/app/src/app/(frontend)/blog/[...slug]/page.tsx
@@ -15,8 +15,6 @@ import { headers } from 'next/headers';
 import { generateBreadcrumbs } from './breadcrumbs';
 import { Post as PayloadPost, Category as PayloadCategory } from '@/payload-types';
 
-const depth = 2;
-
 const getPayloadPostFromParams = async ({ params }: { params: { slug: string[] } }): Promise<PayloadPost | null> => {
   const payload = await getPayloadHMR({
     config,
@@ -37,7 +35,7 @@ const getPayloadPostFromParams = async ({ params }: { params: { slug: string[] }
       slug: { equals: postSlug },
       _status: { equals: 'published' },
     },
-    depth,
+    depth: 1,
   });
 
   if (!payloadPosts.docs.length) {
@@ -147,7 +145,7 @@ const transformPostToBlogPostProps = async (post: PayloadPost): Promise<BlogPost
     where: {
       post: { equals: post.id },
     },
-    depth,
+    depth: 1,
     limit: 0,
     pagination: false,
   });

--- a/app/src/app/(frontend)/blog/category/[...slug]/page.tsx
+++ b/app/src/app/(frontend)/blog/category/[...slug]/page.tsx
@@ -15,8 +15,6 @@ import { sortCategoryByTitle } from '@/utils/blog/category';
 import { payloadRedirect } from '@/payload/utils/payloadRedirect';
 import { generateBreadcrumbs } from './breadcrumbs';
 
-const depth = 2;
-
 const getPayloadCategoryFromParams = async ({
   params,
 }: {
@@ -100,7 +98,7 @@ const CategoryDetailPageHandler = async ({ params: paramsPromise }: { params: Pr
       category: { equals: payloadCategory.id },
       _status: { equals: 'published' },
     },
-    depth,
+    depth: 1,
     limit: 0,
     pagination: false,
   });
@@ -116,7 +114,6 @@ const CategoryDetailPageHandler = async ({ params: paramsPromise }: { params: Pr
         const commentCount = await payload.count({
           collection: 'comments',
           where: { post: { equals: post.id } },
-          depth,
         });
 
         const relatedMeta: BlogPostRelatedMeta = {
@@ -150,7 +147,7 @@ const CategoryDetailPageHandler = async ({ params: paramsPromise }: { params: Pr
   const payloadSubcategories = await payload.find({
     collection: 'category',
     where: { parent: { equals: payloadCategory.id } },
-    depth,
+    depth: 1,
     limit: 0,
     pagination: false,
   });

--- a/app/src/app/(frontend)/blog/category/page.tsx
+++ b/app/src/app/(frontend)/blog/category/page.tsx
@@ -9,8 +9,6 @@ import CategoryPage from '@/containers/CategoryPage';
 import { CategoryWithSubcategories } from '@/containers/CategoryPage/types';
 import { generateBreadcrumbs } from './breadcrumbs';
 
-const depth = 2;
-
 export const metadata: Metadata = {
   title: 'Category',
   description: "Explore Mo's categories for easy navigation through various topics and insights.",
@@ -24,7 +22,7 @@ const CategoryPageHandler = async () => {
   const payloadRootCategories = await payload.find({
     collection: 'category',
     where: { parent: { exists: false } },
-    depth,
+    depth: 1,
     limit: 0,
     pagination: false,
   });
@@ -36,7 +34,7 @@ const CategoryPageHandler = async () => {
         const payloadSubCategories = await payload.find({
           collection: 'category',
           where: { parent: { equals: payloadRootCategory.id } },
-          depth,
+          depth: 1,
           limit: 0,
           pagination: false,
         });

--- a/app/src/app/(frontend)/blog/page.tsx
+++ b/app/src/app/(frontend)/blog/page.tsx
@@ -13,8 +13,6 @@ export const metadata: Metadata = {
   description: "Explore Mo's blog for insights on programming, technology, and other topics of interest.",
 };
 
-const depth = 2;
-
 const BlogPageHandler = async () => {
   const payload = await getPayloadHMR({
     config,
@@ -23,7 +21,7 @@ const BlogPageHandler = async () => {
   const posts = await payload.find({
     collection: 'posts',
     where: { _status: { equals: 'published' } },
-    depth,
+    depth: 1,
     limit: 0,
     pagination: false,
   });
@@ -39,7 +37,6 @@ const BlogPageHandler = async () => {
         const commentCount = await payload.count({
           collection: 'comments',
           where: { post: { equals: post.id } },
-          depth,
         });
 
         const relatedMeta: BlogPostRelatedMeta = {

--- a/app/src/app/(frontend)/page.tsx
+++ b/app/src/app/(frontend)/page.tsx
@@ -7,8 +7,6 @@ import { BlogPostMeta, BlogPostRelatedMeta } from '@/types/blog';
 import { sortBlogPostMetaByPublishedAtDate } from '@/utils/blog/post';
 import { generateBreadcrumbs } from './breadcrumbs';
 
-const depth = 2;
-
 const Home = async () => {
   const payload = await getPayloadHMR({
     config,
@@ -17,7 +15,7 @@ const Home = async () => {
   const posts = await payload.find({
     collection: 'posts',
     where: { _status: { equals: 'published' } },
-    depth,
+    depth: 1,
     limit: 3,
     pagination: false,
     sort: '-publishedAt',
@@ -34,7 +32,6 @@ const Home = async () => {
         const commentCount = await payload.count({
           collection: 'comments',
           where: { post: { equals: post.id } },
-          depth,
         });
 
         const relatedMeta: BlogPostRelatedMeta = {

--- a/app/src/payload/utils/getRedirects.ts
+++ b/app/src/payload/utils/getRedirects.ts
@@ -2,14 +2,14 @@ import { unstable_cache_safe } from '@/utils/next';
 import config from '@payload-config';
 import { getPayloadHMR } from '@payloadcms/next/utilities';
 
-export const getRedirects = async (depth = 1) => {
+export const getRedirects = async () => {
   const payload = await getPayloadHMR({
     config,
   });
 
   const { docs: redirects } = await payload.find({
     collection: 'redirects',
-    depth,
+    depth: 1,
     limit: 0,
     pagination: false,
   });


### PR DESCRIPTION
We can just use `depth: 1` everywhere because we only really consume the top level.