### PR TITLE
Set contentDispositionType to inline for images

### DIFF
--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -18,6 +18,7 @@ const nextConfig = {
     dirs: ['.'],
   },
   images: {
+    contentDispositionType: 'inline',
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
This will allow images to open up without triggering browser for download.

Since all our images are mine, there is no security risk in allowing SVG's to execute malicious code.

Relevant docs:
https://nextjs.org/docs/pages/api-reference/components/image#dangerouslyallowsvg