### PR TITLE
Call payloadRedirect from both generateMetadata and handler

### DIFF
--- a/app/src/app/(frontend)/[...catchAll]/page.tsx
+++ b/app/src/app/(frontend)/[...catchAll]/page.tsx
@@ -14,7 +14,9 @@ export const generateMetadata = async ({
 };
 
 // Any route that isn't handled by other routes will end up here
-const CatchAllHandler = () => {
+const CatchAllHandler = async ({ params: paramsPromise }: { params: Promise<{ catchAll: string[] }> }) => {
+  const params = await paramsPromise;
+  await payloadRedirect({ currentUrl: joinUrl([...params.catchAll]) });
   notFound();
 };
 

--- a/app/src/app/(frontend)/blog/[...slug]/page.tsx
+++ b/app/src/app/(frontend)/blog/[...slug]/page.tsx
@@ -192,6 +192,8 @@ export const generateStaticParams = async () => {
 const BlogPostHandler = async ({ params: paramsPromise }: { params: Promise<{ slug: string[] }> }) => {
   const params = await paramsPromise;
 
+  await payloadRedirect({ currentUrl: joinUrl(['blog', ...params.slug]) });
+
   const post = await getPayloadPostFromParams({ params });
   if (!post) {
     notFound();

--- a/app/src/app/(frontend)/blog/category/[...slug]/page.tsx
+++ b/app/src/app/(frontend)/blog/category/[...slug]/page.tsx
@@ -21,7 +21,6 @@ export const revalidate = 900;
 /**
  * Data fetching
  */
-
 const getPayloadCategoryFromParams = ({ params }: { params: { slug: string[] } }) =>
   unstable_cache_safe(
     async (): Promise<PayloadCategory | null> => {
@@ -217,6 +216,8 @@ export const generateStaticParams = async () => {
  */
 const CategoryDetailPageHandler = async ({ params: paramsPromise }: { params: Promise<{ slug: string[] }> }) => {
   const params = await paramsPromise;
+
+  await payloadRedirect({ currentUrl: joinUrl(['blog', 'category', ...params.slug]) });
 
   const payloadCategory = await getPayloadCategoryFromParams({ params });
   if (!payloadCategory) {


### PR DESCRIPTION
It seems like redirects only work properly when `payloadRedirect` is called from both generateMetadata and handler.

Otherwise, there is a race condition on which is triggered first (generateMetadata  / handler) and depending on which is triggered first and which returns `notFound()` it can leak to 404 being shown prematurely with no redirect taking place.