### PR TITLE
Explicitly specify NODE_ENV

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -27,10 +27,13 @@ COPY --from=builder /project/app/.next/static ./.next/static
 RUN rm -rf ./public ./private
 COPY --from=builder /project/app/public ./public
 
+ENV NODE_ENV=production
+
 EXPOSE 3000
 ENV PORT=3000
 
+ENV HOSTNAME="0.0.0.0"
+
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/next-config-js/output
-ENV HOSTNAME="0.0.0.0"
 CMD ["node", "server.js"]

--- a/app/package.json
+++ b/app/package.json
@@ -21,7 +21,7 @@
     "lint": "cross-env next lint",
     "payload": "cross-env PAYLOAD_CONFIG_PATH=src/payload.config.ts payload",
     "start": "cross-env next start",
-    "start-server": "cross-env HOSTNAME=0.0.0.0 PORT=3000 node .next/standalone/server.js",
+    "start-server": "cross-env NODE_ENV=production HOSTNAME=0.0.0.0 PORT=3000 node .next/standalone/server.js",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
Seems like `NODE_ENV` is prod anyway but doesn't hurt to explicitly set it.