### PR TITLE
Invoke notFound() instead of returning it (Category Detail page)

### DIFF
--- a/app/src/app/(frontend)/blog/[...slug]/page.tsx
+++ b/app/src/app/(frontend)/blog/[...slug]/page.tsx
@@ -133,15 +133,15 @@ export const generateMetadata = async ({
 
   await payloadRedirect({ currentUrl: joinUrl(['blog', ...params.slug]) });
 
-  const post = await getPayloadPostFromParams({ params });
-  if (!post) {
-    console.warn('Failed to find post during generateMetadata.');
+  const payloadPost = await getPayloadPostFromParams({ params });
+  if (!payloadPost) {
+    console.warn(`Failed to find payload post during generateMetadata. Params: ${params.slug.join('/')}`);
     notFound();
   }
 
-  const seoData = post.meta;
-  const fallbackTitle = post.title;
-  const fallbackDescription = post.excerpt;
+  const seoData = payloadPost.meta;
+  const fallbackTitle = payloadPost.title;
+  const fallbackDescription = payloadPost.excerpt;
 
   return {
     title: seoData?.title || fallbackTitle,

--- a/app/src/app/(frontend)/blog/category/[...slug]/page.tsx
+++ b/app/src/app/(frontend)/blog/category/[...slug]/page.tsx
@@ -168,7 +168,7 @@ export const generateMetadata = async ({
   const payloadCategory = await getPayloadCategoryFromParams({ params });
   if (!payloadCategory) {
     console.warn(`Failed to find payload category during generateMetadata. Params: ${params.slug.join('/')}`);
-    return notFound();
+    notFound();
   }
 
   const seoData = payloadCategory.meta;

--- a/app/src/app/(frontend)/blog/category/[...slug]/page.tsx
+++ b/app/src/app/(frontend)/blog/category/[...slug]/page.tsx
@@ -167,12 +167,14 @@ export const generateMetadata = async ({
 
   const payloadCategory = await getPayloadCategoryFromParams({ params });
   if (!payloadCategory) {
-    console.warn('Failed to find payload category during generateMetadata.');
+    console.warn(`Failed to find payload category during generateMetadata. Params: ${params.slug.join('/')}`);
     return notFound();
   }
+
   const seoData = payloadCategory.meta;
   const fallbackTitle = `Category: ${payloadCategory.title}`;
   const fallbackDescription = payloadCategory.description;
+
   return {
     title: seoData?.title || fallbackTitle,
     description: seoData?.description || fallbackDescription,


### PR DESCRIPTION
We should only invoke `notFound()` like we do for the blog posts instead of returning it.

This may be what is causing the #220 issue.