### PR TITLE
Improve category slugs to category lookup

### DIFF
--- a/app/src/app/(frontend)/blog/[...slug]/page.tsx
+++ b/app/src/app/(frontend)/blog/[...slug]/page.tsx
@@ -64,7 +64,7 @@ const getPayloadPostFromParams = ({ params }: { params: { slug: string[] } }) =>
 
       return postsMatchingCategorySlugUrl[0];
     },
-    [`get-payload-post-from-params-${params.slug.join('-')}`],
+    [`getPayloadPostFromParams:${params.slug.join('-')}`],
     { revalidate: revalidate },
   )();
 
@@ -117,7 +117,7 @@ const transformPostToBlogPostProps = (post: PayloadPost) =>
 
       return blogPostProps;
     },
-    [`transformPostToBlogPostProps-${post.id}`],
+    [`transformPostToBlogPostProps:${post.id}`],
     { revalidate: revalidate },
   )();
 

--- a/app/src/app/(frontend)/blog/page.tsx
+++ b/app/src/app/(frontend)/blog/page.tsx
@@ -58,7 +58,7 @@ const getAllBlogPostMetas = unstable_cache_safe(
       .filter((obj) => obj !== null)
       .sort(sortBlogPostMetaByPublishedAtDate);
   },
-  [`get-all-blog-post-metas`],
+  [`getAllBlogPostMetas`],
   { revalidate: revalidate },
 );
 

--- a/app/src/payload/utils/docs/getDocument.ts
+++ b/app/src/payload/utils/docs/getDocument.ts
@@ -20,7 +20,7 @@ export const getDocumentById = async (
 export const getCachedDocumentById = (relationTo: CollectionSlug, docId: number) =>
   unstable_cache_safe(
     async () => getDocumentById(relationTo, docId),
-    [`payload-get-document-by-id-${relationTo}-${docId}`],
+    [`payload:getDocumentById:${relationTo}:${docId}`],
     {
       tags: ['payload', `payload:collection:${relationTo}`, `payload:collection:${relationTo}:${docId}`],
     },

--- a/app/src/payload/utils/redirects/getRedirects.ts
+++ b/app/src/payload/utils/redirects/getRedirects.ts
@@ -20,6 +20,6 @@ export const getRedirects = async () => {
 /**
  * Cache all redirects together to avoid multiple fetches.
  */
-export const getCachedRedirects = unstable_cache_safe(async () => getRedirects(), ['redirects'], {
-  tags: ['redirects'],
+export const getCachedRedirects = unstable_cache_safe(async () => getRedirects(), ['payload:getRedirects'], {
+  tags: ['payload', 'redirects'],
 });

--- a/app/src/utils/gravatar/gravatar.ts
+++ b/app/src/utils/gravatar/gravatar.ts
@@ -34,6 +34,6 @@ export const getCachedGravatarAvatarUrl = ({ email, size = 80, rating = 'pg' }: 
     async () => {
       return getGravatarAvatarUrl({ email, size, rating });
     },
-    [`getGravatarAvatarUrl:${email}:${size}:${rating}`],
+    [`gravatar:getGravatarAvatarUrl:${email}:${size}:${rating}`],
     { tags: ['gravatar'], revalidate: 900 },
   )();

--- a/app/src/utils/photography/getLatestPhotographyImages.ts
+++ b/app/src/utils/photography/getLatestPhotographyImages.ts
@@ -51,7 +51,7 @@ export const getLatestPhotographyImages = async ({
 
 export const getCachedLatestPhotographyImages = unstable_cache_safe(
   async () => getLatestPhotographyImages({}),
-  ['getLatestPhotographyImages'],
+  ['photography:getLatestPhotographyImages'],
   {
     revalidate: 900,
   },


### PR DESCRIPTION
Changes
* Use non-recursive approach to find category based on category slugs. Improves speed. This may address #220 
* Make `unstable_cache` keys use consistent format (similar to format used for `tags`). 
  * Example: `example:component:name-of-key`