### PR TITLE
Increase right margin to avoid text clipping

### DIFF
--- a/app/src/components/GitContributionGraph/GitContributionGraph.tsx
+++ b/app/src/components/GitContributionGraph/GitContributionGraph.tsx
@@ -64,7 +64,7 @@ export const GitContributionGraph = ({ data }: GitContributionGraphProps) => {
     calendar: {
       top: 20,
       left: 50,
-      right: 5,
+      right: 20,
       cellSize: [20],
       range: [startDate, endDate],
       itemStyle: {


### PR DESCRIPTION
Sometimes the Month name can be clipped on right side due to limited margin:
![image](https://github.com/user-attachments/assets/ebad6a14-a0c2-48f4-8d52-333875e69930)
