### PR TITLE
Improve blog summary view on mobile

### DIFF
--- a/app/src/components/BlogSummary/BlogSummary.tsx
+++ b/app/src/components/BlogSummary/BlogSummary.tsx
@@ -6,6 +6,7 @@ import {
   IconAndTextContainer,
   DetailIconWrapper as IconWrapper,
   StyledLink,
+  StyledTime,
 } from './styled';
 import { BlogSummaryProps } from './types';
 import Link from 'next/link';
@@ -58,9 +59,9 @@ export const BlogSummary = ({
             <IconWrapper>
               <CalendarSvg />
             </IconWrapper>
-            <time dateTime={publishedAtDate.toISOString()}>
+            <StyledTime dateTime={publishedAtDate.toISOString()}>
               <ClientFormattedDate date={publishedAtDate} format="d MMMM yyyy" />
-            </time>
+            </StyledTime>
           </IconAndTextContainer>
         </Detail>
         <Detail data-tooltip-id="global-tooltip" data-tooltip-content="Category">

--- a/app/src/components/BlogSummary/BlogSummary.tsx
+++ b/app/src/components/BlogSummary/BlogSummary.tsx
@@ -15,6 +15,7 @@ import CategorySvg from '@/assets/icons/boxicons/bx-category.svg';
 import CommentDetailSvg from '@/assets/icons/boxicons/bx-comment-detail.svg';
 import BarChartSvg from '@/assets/icons/boxicons/bx-bar-chart.svg';
 import { ClientFormattedDate } from '@/components/ClientFormattedDate';
+import { formatCompactNumber } from '@/utils/format';
 
 export const BlogSummary = ({
   blogPostMeta,
@@ -25,6 +26,14 @@ export const BlogSummary = ({
   showExcerpt = true,
 }: BlogSummaryProps) => {
   const publishedAtDate = new Date(blogPostMeta.post.publishedAt);
+
+  const standardViewCount = Intl.NumberFormat('en', { notation: 'standard' }).format(blogPostMeta.post.views);
+  const compactViewCount = formatCompactNumber(blogPostMeta.post.views);
+
+  const standardCommentCount = Intl.NumberFormat('en', { notation: 'standard' }).format(
+    blogPostMeta.related.commentCount,
+  );
+  const compactCommentCount = formatCompactNumber(blogPostMeta.related.commentCount);
 
   const categoryElement = (
     <IconAndTextContainer>
@@ -40,7 +49,7 @@ export const BlogSummary = ({
       <IconWrapper>
         <CommentDetailSvg />
       </IconWrapper>
-      <span>{blogPostMeta.related.commentCount}</span>
+      <span>{compactCommentCount}</span>
     </IconAndTextContainer>
   );
 
@@ -71,15 +80,15 @@ export const BlogSummary = ({
             categoryElement
           )}
         </Detail>
-        <Detail data-tooltip-id="global-tooltip" data-tooltip-content="Views">
+        <Detail data-tooltip-id="global-tooltip" data-tooltip-html={`${standardViewCount} views`}>
           <IconAndTextContainer>
             <IconWrapper>
               <BarChartSvg />
             </IconWrapper>
-            <span>{blogPostMeta.post.views}</span>
+            <span>{compactViewCount}</span>
           </IconAndTextContainer>
         </Detail>
-        <Detail data-tooltip-id="global-tooltip" data-tooltip-content="Comments">
+        <Detail data-tooltip-id="global-tooltip" data-tooltip-html={`${standardCommentCount} comments`}>
           {commentsAnchor ? (
             <StyledLink href={`${blogPostMeta.post.url}#${commentsAnchor}`}>{commentCountElement}</StyledLink>
           ) : (

--- a/app/src/components/BlogSummary/styled.ts
+++ b/app/src/components/BlogSummary/styled.ts
@@ -55,3 +55,7 @@ export const IconAndTextContainer = styled.span`
   justify-content: center;
   align-items: center;
 `;
+
+export const StyledTime = styled.time`
+  min-width: max-content;
+`;

--- a/app/src/utils/format/index.ts
+++ b/app/src/utils/format/index.ts
@@ -1,0 +1,1 @@
+export { formatCompactNumber } from './number';

--- a/app/src/utils/format/number.test.ts
+++ b/app/src/utils/format/number.test.ts
@@ -1,0 +1,64 @@
+import { formatCompactNumber } from './number';
+
+describe('formatCompactNumber', () => {
+  it('returns raw number for < 1K', () => {
+    expect(formatCompactNumber(0)).toBe('0');
+    expect(formatCompactNumber(-0)).toBe('0');
+    expect(formatCompactNumber(17)).toBe('17');
+    expect(formatCompactNumber(-17)).toBe('-17');
+    expect(formatCompactNumber(999)).toBe('999');
+    expect(formatCompactNumber(-999)).toBe('-999');
+  });
+
+  it('formats 1K-9.9K with decimal', () => {
+    expect(formatCompactNumber(1000)).toBe('1K');
+    expect(formatCompactNumber(-1000)).toBe('-1K');
+    expect(formatCompactNumber(1200)).toBe('1.2K');
+    expect(formatCompactNumber(-1200)).toBe('-1.2K');
+    expect(formatCompactNumber(9999)).toBe('9.9K');
+    expect(formatCompactNumber(-9999)).toBe('-9.9K');
+  });
+
+  it('formats 10K-999K with no decimal', () => {
+    expect(formatCompactNumber(10000)).toBe('10K');
+    expect(formatCompactNumber(-10000)).toBe('-10K');
+    expect(formatCompactNumber(123456)).toBe('123K');
+    expect(formatCompactNumber(-123456)).toBe('-123K');
+    expect(formatCompactNumber(999999)).toBe('999K');
+    expect(formatCompactNumber(-999999)).toBe('-999K');
+  });
+
+  it('formats 1M-9.9M with decimal', () => {
+    expect(formatCompactNumber(1_000_000)).toBe('1M');
+    expect(formatCompactNumber(-1_000_000)).toBe('-1M');
+    expect(formatCompactNumber(1_250_000)).toBe('1.2M');
+    expect(formatCompactNumber(-1_250_000)).toBe('-1.2M');
+    expect(formatCompactNumber(9_999_999)).toBe('9.9M');
+    expect(formatCompactNumber(-9_999_999)).toBe('-9.9M');
+  });
+
+  it('formats 10M-999M with no decimal', () => {
+    expect(formatCompactNumber(10_000_000)).toBe('10M');
+    expect(formatCompactNumber(-10_000_000)).toBe('-10M');
+    expect(formatCompactNumber(123_456_789)).toBe('123M');
+    expect(formatCompactNumber(-123_456_789)).toBe('-123M');
+    expect(formatCompactNumber(999_999_999)).toBe('999M');
+    expect(formatCompactNumber(-999_999_999)).toBe('-999M');
+  });
+
+  it('formats 1B-9.9B with decimal', () => {
+    expect(formatCompactNumber(1_000_000_000)).toBe('1B');
+    expect(formatCompactNumber(-1_000_000_000)).toBe('-1B');
+    expect(formatCompactNumber(1_250_000_000)).toBe('1.2B');
+    expect(formatCompactNumber(-1_250_000_000)).toBe('-1.2B');
+    expect(formatCompactNumber(9_999_999_999)).toBe('9.9B');
+    expect(formatCompactNumber(-9_999_999_999)).toBe('-9.9B');
+  });
+
+  it('formats 10B+ with no decimal', () => {
+    expect(formatCompactNumber(10_000_000_000)).toBe('10B');
+    expect(formatCompactNumber(-10_000_000_000)).toBe('-10B');
+    expect(formatCompactNumber(12_345_678_901)).toBe('12B');
+    expect(formatCompactNumber(-12_345_678_901)).toBe('-12B');
+  });
+});

--- a/app/src/utils/format/number.ts
+++ b/app/src/utils/format/number.ts
@@ -1,0 +1,18 @@
+// TODO: This can be replaced with `Intl.NumberFormat('en', { notation: 'compact', roundingMode: 'floor' }).format(value)` after targetting ES2023 in tsconfig.
+export const formatCompactNumber = (value: number): string => {
+  const isNegative = value < 0;
+  const abs = Math.floor(Math.abs(value));
+
+  const format = (divisor: number, suffix: string, decimal = false) =>
+    (isNegative ? '-' : '') +
+    (decimal ? `${Math.floor(abs / (divisor / 10)) / 10}${suffix}` : `${Math.floor(abs / divisor)}${suffix}`);
+
+  if (abs >= 10_000_000_000) return format(1_000_000_000, 'B');
+  if (abs >= 1_000_000_000) return format(1_000_000_000, 'B', true);
+  if (abs >= 10_000_000) return format(1_000_000, 'M');
+  if (abs >= 1_000_000) return format(1_000_000, 'M', true);
+  if (abs >= 10_000) return format(1_000, 'K');
+  if (abs >= 1_000) return format(1_000, 'K', true);
+
+  return (isNegative ? '-' : '') + `${abs}`;
+};


### PR DESCRIPTION
Issues:
Fixes #248 

Approach used was to:
- Always make the date use `max-content` so its shown.
- Make category wrap as needed
- Use compact numbers for view count + comment count.

Tested & works well at: 380px & 400px. 