### PR TITLE
Set Sharp and <Image /> quality to 100

### DIFF
--- a/app/src/app/(payload)/admin/importMap.js
+++ b/app/src/app/(payload)/admin/importMap.js
@@ -1,5 +1,6 @@
 import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
+import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { InlineToolbarFeatureClient as InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { FixedToolbarFeatureClient as FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
@@ -31,6 +32,7 @@ import { SlugComponent as SlugComponent_97028a0b9b0cab2bc9a9b24a74dfbaa3 } from 
 export const importMap = {
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
+  "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient": InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#FixedToolbarFeatureClient": FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,

--- a/app/src/components/ThemedPicture/ThemedPicture.tsx
+++ b/app/src/components/ThemedPicture/ThemedPicture.tsx
@@ -36,6 +36,6 @@ export const ThemedPicture = ({ dark, light }: ThemedPictureProps) => {
       }}
     ></img>
   ) : (
-    <Image src={imageSrc} alt={imageAlt} width={imageWidth} height={imageHeight} style={imageStyle} />
+    <Image src={imageSrc} alt={imageAlt} width={imageWidth} height={imageHeight} style={imageStyle} quality={100} />
   );
 };

--- a/app/src/containers/AboutPage/AboutPage.tsx
+++ b/app/src/containers/AboutPage/AboutPage.tsx
@@ -49,7 +49,7 @@ export const AboutPage = () => {
         </IconWrapper>
       </p>
       <ImageWrapper>
-        <Image src="/images/about/sydney.webp" alt="Sydney" fill />
+        <Image src="/images/about/sydney.webp" alt="Sydney" fill quality={75} />
       </ImageWrapper>
       <p>
         I am a full stack Software Engineer and a{' '}

--- a/app/src/containers/BlogPost/CommentSection/CommentSection.tsx
+++ b/app/src/containers/BlogPost/CommentSection/CommentSection.tsx
@@ -92,7 +92,13 @@ const SingleComment = ({ comment, postId, onSuccess, commentsEnabled }: SingleCo
     <SingleCommentContainer id={`comment-${comment.id}`}>
       <CommentBox>
         <DisplayPicture $isCustomDisplayPicture={isCustomDisplayPicture}>
-          <Image src={displayPictureUrl} alt={`Display picture for ${comment.displayName}`} width={55} height={55} />
+          <Image
+            src={displayPictureUrl}
+            alt={`Display picture for ${comment.displayName}`}
+            width={55}
+            height={55}
+            quality={100}
+          />
         </DisplayPicture>
         <CommentMain>
           <CommentMetaHeader>

--- a/app/src/payload/blocks/MediaBlock/Component/MediaBlockImage/index.tsx
+++ b/app/src/payload/blocks/MediaBlock/Component/MediaBlockImage/index.tsx
@@ -39,6 +39,7 @@ export const MediaBlockImage = ({ mediaDark, mediaLight, widthOverride, heightOv
         width={darkDimensions.width}
         height={darkDimensions.height}
         style={darkDimensions.style}
+        quality={100}
       />
     );
   }

--- a/app/src/payload/collections/Media.ts
+++ b/app/src/payload/collections/Media.ts
@@ -32,8 +32,14 @@ export const Media: CollectionConfig = {
   ],
   upload: {
     mimeTypes: ['image/*', 'video/*'],
-    // Use webp for all media for maximum compression
-    formatOptions: { format: 'webp' },
+    // Use webp as preferred format for all media
+    formatOptions: {
+      format: 'webp',
+      options: {
+        lossless: true,
+        effort: 6,
+      },
+    },
     // Upload to a public directory in Next.js making them publicly accessible even outside of Payload
     staticDir: path.resolve('public/uploads/media'),
   },


### PR DESCRIPTION
Got annoyed with the default Sharp (`80`) and Next values (`75`) for images.
Always have artefacts in the image that look messy.

Instead lets do 100% lossless quality all the time.
The difference is likely <1 MB for most of my blog posts so not a huge deal.