### PR TITLE
Improve table styling, especially for tightly packed tables

### DIFF
--- a/app/src/containers/BlogPost/styled.ts
+++ b/app/src/containers/BlogPost/styled.ts
@@ -37,15 +37,24 @@ export const BlogPostArticle = styled.article`
   }
 
   /* Tables */
-  & table {
-    margin: 0 auto;
+  & .table-wrapper {
     width: 100%;
+    overflow-x: auto;
+  }
 
-    /* Break text when vw is limited */
-    * {
-      word-break: break-word;
-      white-space: normal;
-    }
+  & .table-wrapper > table {
+    font-size: 0.9em; /* support tightly packed tables better */
+    width: 100%; /* fill container when it fits */
+    min-width: max-content; /* but don't shrink below intrinsic width */
+    table-layout: auto;
+    margin: 0 auto;
+  }
+
+  & .table-wrapper th *,
+  & .table-wrapper td * {
+    white-space: nowrap;
+    word-break: keep-all;
+    margin: 0;
   }
 
   /* Embeds */

--- a/app/src/payload/converter/reactnode/tables/table.tsx
+++ b/app/src/payload/converter/reactnode/tables/table.tsx
@@ -36,30 +36,32 @@ export const TableReactNodeConverter: ReactNodeConverter<SerializedTableNode> = 
     }
 
     return (
-      <table>
-        {headerRows.length > 0 && (
-          <thead>
+      <div className="table-wrapper">
+        <table>
+          {headerRows.length > 0 && (
+            <thead>
+              {convertLexicalNodesToReactNode({
+                converters,
+                lexicalNodes: headerRows,
+                parent: {
+                  ...node,
+                  parent,
+                },
+              })}
+            </thead>
+          )}
+          <tbody>
             {convertLexicalNodesToReactNode({
               converters,
-              lexicalNodes: headerRows,
+              lexicalNodes: bodyRows,
               parent: {
                 ...node,
                 parent,
               },
             })}
-          </thead>
-        )}
-        <tbody>
-          {convertLexicalNodesToReactNode({
-            converters,
-            lexicalNodes: bodyRows,
-            parent: {
-              ...node,
-              parent,
-            },
-          })}
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      </div>
     );
   },
   nodeTypes: ['table'],


### PR DESCRIPTION
This is needed because tables looked horrible on mobile (squished together and not readable):
<img width="582" height="837" alt="image" src="https://github.com/user-attachments/assets/ef820754-9b71-4279-952f-a8c5463195c2" />

Changes:
- `0.9 em` font to help to fit things in
- Tables cells don't wrap anymore 
- Horizontal scroll appears if table won't fit

Impact:
- Looks good on mobile and low viewport width screens
- I am responsible for making sure table cells (th and td) are not too long
