### PR TITLE
Increase server actions body size limit

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -32,6 +32,9 @@ const nextConfig: NextConfig = {
         expire: undefined, // forever
       },
     },
+    serverActions: {
+      bodySizeLimit: '3mb' /* Support larger sized chunked updates in Payload */,
+    },
   },
   images: {
     contentDispositionType: 'inline',


### PR DESCRIPTION
Some of the chucked updated Payload makes is failing:
* 1,061,775 bytes ≈ 1.013 MiB
* 1,578,867 bytes ≈ 1.506 MiB

Usually when making posts with huge tables in them (lots of data and structure in JSON).

As per: https://nextjs.org/docs/app/api-reference/config/next-config-js/serverActions#bodysizelimit

We will increase the limit from `1mb` (default) to `3mb`