### PR TITLE
Update payload from 3.81.0 to 3.84.1 & Force Sharp resolution

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -30,13 +30,13 @@
     "@next/third-parties": "15.4.11",
     "@octokit/graphql": "^9.0.3",
     "@octokit/rest": "^22.0.1",
-    "@payloadcms/db-postgres": "3.81.0",
-    "@payloadcms/email-nodemailer": "3.81.0",
-    "@payloadcms/next": "3.81.0",
-    "@payloadcms/plugin-nested-docs": "3.81.0",
-    "@payloadcms/plugin-redirects": "3.81.0",
-    "@payloadcms/plugin-seo": "3.81.0",
-    "@payloadcms/richtext-lexical": "3.81.0",
+    "@payloadcms/db-postgres": "3.84.1",
+    "@payloadcms/email-nodemailer": "3.84.1",
+    "@payloadcms/next": "3.84.1",
+    "@payloadcms/plugin-nested-docs": "3.84.1",
+    "@payloadcms/plugin-redirects": "3.84.1",
+    "@payloadcms/plugin-seo": "3.84.1",
+    "@payloadcms/richtext-lexical": "3.84.1",
     "@react-email/components": "^1.0.11",
     "@react-email/render": "^2.0.5",
     "crawler-user-agents": "^1.37.0",
@@ -52,7 +52,7 @@
     "next": "15.4.11",
     "next-themes": "^0.4.6",
     "node-cron": "^4.2.1",
-    "payload": "3.81.0",
+    "payload": "3.84.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-spinners": "^0.17.0",
@@ -96,6 +96,9 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.58.0"
+  },
+  "resolutions": {
+    "sharp": "0.34.5"
   },
   "engines": {
     "node": ">=24"

--- a/app/src/app/(payload)/admin/importMap.js
+++ b/app/src/app/(payload)/admin/importMap.js
@@ -30,6 +30,7 @@ import { MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea
 import { SlugComponent as SlugComponent_97028a0b9b0cab2bc9a9b24a74dfbaa3 } from '@payload/fields/slug/SlugComponent'
 import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
+/** @type import('payload').ImportMap */
 export const importMap = {
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2157,15 +2157,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/runtime@npm:^1.4.4":
-  version: 1.4.5
-  resolution: "@emnapi/runtime@npm:1.4.5"
-  dependencies:
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/37a0278be5ac81e918efe36f1449875cbafba947039c53c65a1f8fc238001b866446fc66041513b286baaff5d6f9bec667f5164b3ca481373a8d9cb65bfc984b
-  languageName: node
-  linkType: hard
-
 "@emnapi/runtime@npm:^1.7.0":
   version: 1.8.1
   resolution: "@emnapi/runtime@npm:1.8.1"
@@ -3186,18 +3177,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-darwin-arm64@npm:0.34.3":
-  version: 0.34.3
-  resolution: "@img/sharp-darwin-arm64@npm:0.34.3"
-  dependencies:
-    "@img/sharp-libvips-darwin-arm64": "npm:1.2.0"
-  dependenciesMeta:
-    "@img/sharp-libvips-darwin-arm64":
-      optional: true
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@img/sharp-darwin-arm64@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-darwin-arm64@npm:0.34.5"
@@ -3207,18 +3186,6 @@ __metadata:
     "@img/sharp-libvips-darwin-arm64":
       optional: true
   conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@img/sharp-darwin-x64@npm:0.34.3":
-  version: 0.34.3
-  resolution: "@img/sharp-darwin-x64@npm:0.34.3"
-  dependencies:
-    "@img/sharp-libvips-darwin-x64": "npm:1.2.0"
-  dependenciesMeta:
-    "@img/sharp-libvips-darwin-x64":
-      optional: true
-  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -3234,24 +3201,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-libvips-darwin-arm64@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@img/sharp-libvips-darwin-arm64@npm:1.2.0"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@img/sharp-libvips-darwin-arm64@npm:1.2.4":
   version: 1.2.4
   resolution: "@img/sharp-libvips-darwin-arm64@npm:1.2.4"
   conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@img/sharp-libvips-darwin-x64@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@img/sharp-libvips-darwin-x64@npm:1.2.0"
-  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -3262,13 +3215,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-libvips-linux-arm64@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@img/sharp-libvips-linux-arm64@npm:1.2.0"
-  conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@img/sharp-libvips-linux-arm64@npm:1.2.4":
   version: 1.2.4
   resolution: "@img/sharp-libvips-linux-arm64@npm:1.2.4"
@@ -3276,24 +3222,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-libvips-linux-arm@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@img/sharp-libvips-linux-arm@npm:1.2.0"
-  conditions: os=linux & cpu=arm & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@img/sharp-libvips-linux-arm@npm:1.2.4":
   version: 1.2.4
   resolution: "@img/sharp-libvips-linux-arm@npm:1.2.4"
   conditions: os=linux & cpu=arm & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@img/sharp-libvips-linux-ppc64@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@img/sharp-libvips-linux-ppc64@npm:1.2.0"
-  conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -3311,24 +3243,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-libvips-linux-s390x@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@img/sharp-libvips-linux-s390x@npm:1.2.0"
-  conditions: os=linux & cpu=s390x & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@img/sharp-libvips-linux-s390x@npm:1.2.4":
   version: 1.2.4
   resolution: "@img/sharp-libvips-linux-s390x@npm:1.2.4"
   conditions: os=linux & cpu=s390x & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@img/sharp-libvips-linux-x64@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@img/sharp-libvips-linux-x64@npm:1.2.0"
-  conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -3339,13 +3257,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-libvips-linuxmusl-arm64@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@img/sharp-libvips-linuxmusl-arm64@npm:1.2.0"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
 "@img/sharp-libvips-linuxmusl-arm64@npm:1.2.4":
   version: 1.2.4
   resolution: "@img/sharp-libvips-linuxmusl-arm64@npm:1.2.4"
@@ -3353,29 +3264,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-libvips-linuxmusl-x64@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@img/sharp-libvips-linuxmusl-x64@npm:1.2.0"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
 "@img/sharp-libvips-linuxmusl-x64@npm:1.2.4":
   version: 1.2.4
   resolution: "@img/sharp-libvips-linuxmusl-x64@npm:1.2.4"
   conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@img/sharp-linux-arm64@npm:0.34.3":
-  version: 0.34.3
-  resolution: "@img/sharp-linux-arm64@npm:0.34.3"
-  dependencies:
-    "@img/sharp-libvips-linux-arm64": "npm:1.2.0"
-  dependenciesMeta:
-    "@img/sharp-libvips-linux-arm64":
-      optional: true
-  conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -3391,18 +3283,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-linux-arm@npm:0.34.3":
-  version: 0.34.3
-  resolution: "@img/sharp-linux-arm@npm:0.34.3"
-  dependencies:
-    "@img/sharp-libvips-linux-arm": "npm:1.2.0"
-  dependenciesMeta:
-    "@img/sharp-libvips-linux-arm":
-      optional: true
-  conditions: os=linux & cpu=arm & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@img/sharp-linux-arm@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-linux-arm@npm:0.34.5"
@@ -3412,18 +3292,6 @@ __metadata:
     "@img/sharp-libvips-linux-arm":
       optional: true
   conditions: os=linux & cpu=arm & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@img/sharp-linux-ppc64@npm:0.34.3":
-  version: 0.34.3
-  resolution: "@img/sharp-linux-ppc64@npm:0.34.3"
-  dependencies:
-    "@img/sharp-libvips-linux-ppc64": "npm:1.2.0"
-  dependenciesMeta:
-    "@img/sharp-libvips-linux-ppc64":
-      optional: true
-  conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -3451,18 +3319,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-linux-s390x@npm:0.34.3":
-  version: 0.34.3
-  resolution: "@img/sharp-linux-s390x@npm:0.34.3"
-  dependencies:
-    "@img/sharp-libvips-linux-s390x": "npm:1.2.0"
-  dependenciesMeta:
-    "@img/sharp-libvips-linux-s390x":
-      optional: true
-  conditions: os=linux & cpu=s390x & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@img/sharp-linux-s390x@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-linux-s390x@npm:0.34.5"
@@ -3472,18 +3328,6 @@ __metadata:
     "@img/sharp-libvips-linux-s390x":
       optional: true
   conditions: os=linux & cpu=s390x & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@img/sharp-linux-x64@npm:0.34.3":
-  version: 0.34.3
-  resolution: "@img/sharp-linux-x64@npm:0.34.3"
-  dependencies:
-    "@img/sharp-libvips-linux-x64": "npm:1.2.0"
-  dependenciesMeta:
-    "@img/sharp-libvips-linux-x64":
-      optional: true
-  conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -3499,18 +3343,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-linuxmusl-arm64@npm:0.34.3":
-  version: 0.34.3
-  resolution: "@img/sharp-linuxmusl-arm64@npm:0.34.3"
-  dependencies:
-    "@img/sharp-libvips-linuxmusl-arm64": "npm:1.2.0"
-  dependenciesMeta:
-    "@img/sharp-libvips-linuxmusl-arm64":
-      optional: true
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
 "@img/sharp-linuxmusl-arm64@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-linuxmusl-arm64@npm:0.34.5"
@@ -3520,18 +3352,6 @@ __metadata:
     "@img/sharp-libvips-linuxmusl-arm64":
       optional: true
   conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@img/sharp-linuxmusl-x64@npm:0.34.3":
-  version: 0.34.3
-  resolution: "@img/sharp-linuxmusl-x64@npm:0.34.3"
-  dependencies:
-    "@img/sharp-libvips-linuxmusl-x64": "npm:1.2.0"
-  dependenciesMeta:
-    "@img/sharp-libvips-linuxmusl-x64":
-      optional: true
-  conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
@@ -3547,28 +3367,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-wasm32@npm:0.34.3":
-  version: 0.34.3
-  resolution: "@img/sharp-wasm32@npm:0.34.3"
-  dependencies:
-    "@emnapi/runtime": "npm:^1.4.4"
-  conditions: cpu=wasm32
-  languageName: node
-  linkType: hard
-
 "@img/sharp-wasm32@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-wasm32@npm:0.34.5"
   dependencies:
     "@emnapi/runtime": "npm:^1.7.0"
   conditions: cpu=wasm32
-  languageName: node
-  linkType: hard
-
-"@img/sharp-win32-arm64@npm:0.34.3":
-  version: 0.34.3
-  resolution: "@img/sharp-win32-arm64@npm:0.34.3"
-  conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -3579,24 +3383,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-win32-ia32@npm:0.34.3":
-  version: 0.34.3
-  resolution: "@img/sharp-win32-ia32@npm:0.34.3"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
 "@img/sharp-win32-ia32@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-win32-ia32@npm:0.34.5"
   conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@img/sharp-win32-x64@npm:0.34.3":
-  version: 0.34.3
-  resolution: "@img/sharp-win32-x64@npm:0.34.3"
-  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -4656,55 +4446,55 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@payloadcms/db-postgres@npm:3.81.0":
-  version: 3.81.0
-  resolution: "@payloadcms/db-postgres@npm:3.81.0"
+"@payloadcms/db-postgres@npm:3.84.1":
+  version: 3.84.1
+  resolution: "@payloadcms/db-postgres@npm:3.84.1"
   dependencies:
-    "@payloadcms/drizzle": "npm:3.81.0"
-    "@types/pg": "npm:8.10.2"
+    "@payloadcms/drizzle": "npm:3.84.1"
+    "@types/pg": "npm:8.20.0"
     console-table-printer: "npm:2.12.1"
     drizzle-kit: "npm:0.31.7"
-    drizzle-orm: "npm:0.44.7"
-    pg: "npm:8.16.3"
+    drizzle-orm: "npm:0.45.2"
+    pg: "npm:8.20.0"
     prompts: "npm:2.4.2"
     to-snake-case: "npm:1.0.0"
-    uuid: "npm:10.0.0"
+    uuid: "npm:11.1.0"
   peerDependencies:
-    payload: 3.81.0
-  checksum: 10c0/26c5c78af3d51a9324abb5463b6194b3939793f8039bd8ba0a252d612c61399ca30af40494ea010af09c7ed2a2207e49d0d336057ed07664d4d408d08f3c0862
+    payload: 3.84.1
+  checksum: 10c0/2420b9b3dd26a658f3c6abbf6ad0ebb3ff9add05b2ea4cc6478e281d038223234be5f8e0731bb059a5dfc4b12dbfd05c7aff78605ef6e2a74e5a816d0c438a6b
   languageName: node
   linkType: hard
 
-"@payloadcms/drizzle@npm:3.81.0":
-  version: 3.81.0
-  resolution: "@payloadcms/drizzle@npm:3.81.0"
+"@payloadcms/drizzle@npm:3.84.1":
+  version: 3.84.1
+  resolution: "@payloadcms/drizzle@npm:3.84.1"
   dependencies:
     console-table-printer: "npm:2.12.1"
     dequal: "npm:2.0.3"
-    drizzle-orm: "npm:0.44.7"
+    drizzle-orm: "npm:0.45.2"
     prompts: "npm:2.4.2"
     to-snake-case: "npm:1.0.0"
-    uuid: "npm:9.0.0"
+    uuid: "npm:11.1.0"
   peerDependencies:
-    payload: 3.81.0
-  checksum: 10c0/316e65896dbb5ef25b610a769e88c126862dfd02d4e354e6cf265d72036a3f08c3805b1727ccb86e3a711b3c000e75ec5ec449f3e0ee1b7874ba37f056dc9af3
+    payload: 3.84.1
+  checksum: 10c0/8c3ff9af774d38817bf73a595aef0a9a29fd21429c09ee9d1097748ea2b537a215fa0f9e0d600f04a0c46501dfd686833ace64b5c53f47cad9fbba37997a3e4e
   languageName: node
   linkType: hard
 
-"@payloadcms/email-nodemailer@npm:3.81.0":
-  version: 3.81.0
-  resolution: "@payloadcms/email-nodemailer@npm:3.81.0"
+"@payloadcms/email-nodemailer@npm:3.84.1":
+  version: 3.84.1
+  resolution: "@payloadcms/email-nodemailer@npm:3.84.1"
   dependencies:
     nodemailer: "npm:7.0.12"
   peerDependencies:
-    payload: 3.81.0
-  checksum: 10c0/db80eb976c44415e3a1ffe3f89e43376ca08ffd9897067ed6e044a73776f706bd7c5a013323ee4f6acba281df4594613641aefd0c10e52cb096761b8bebb5ca2
+    payload: 3.84.1
+  checksum: 10c0/1539c0dc477fc66a6e0b0ff968af9f89ce260a950e4f9fe32adea55aff76ed769abe212fea80ee808daa8cc31263c20960a372613b556cf8436acdc39c9ba7a8
   languageName: node
   linkType: hard
 
-"@payloadcms/graphql@npm:3.81.0":
-  version: 3.81.0
-  resolution: "@payloadcms/graphql@npm:3.81.0"
+"@payloadcms/graphql@npm:3.84.1":
+  version: 3.84.1
+  resolution: "@payloadcms/graphql@npm:3.84.1"
   dependencies:
     graphql-scalars: "npm:1.22.2"
     pluralize: "npm:8.0.0"
@@ -4712,23 +4502,23 @@ __metadata:
     tsx: "npm:4.21.0"
   peerDependencies:
     graphql: ^16.8.1
-    payload: 3.81.0
+    payload: 3.84.1
   bin:
     payload-graphql: bin.js
-  checksum: 10c0/ebffdac23412662e1cf737bec2fa830a99422792cddd8e8dd7ebc6b900a2d648d76e1a2ee1d51f0df1a18f9efe16ca6599de3ec544b28117aa701dda42f12de7
+  checksum: 10c0/2fc190905d62d7ca6d501266969e2721fa70b26c31585f31afc3b40fa718ebe63d90cf5bcf1fe5b4b9d8633318615b0c1bc5aa19b08bb772691eab677bd01621
   languageName: node
   linkType: hard
 
-"@payloadcms/next@npm:3.81.0":
-  version: 3.81.0
-  resolution: "@payloadcms/next@npm:3.81.0"
+"@payloadcms/next@npm:3.84.1":
+  version: 3.84.1
+  resolution: "@payloadcms/next@npm:3.84.1"
   dependencies:
     "@dnd-kit/core": "npm:6.3.1"
     "@dnd-kit/modifiers": "npm:9.0.0"
     "@dnd-kit/sortable": "npm:10.0.0"
-    "@payloadcms/graphql": "npm:3.81.0"
-    "@payloadcms/translations": "npm:3.81.0"
-    "@payloadcms/ui": "npm:3.81.0"
+    "@payloadcms/graphql": "npm:3.84.1"
+    "@payloadcms/translations": "npm:3.84.1"
+    "@payloadcms/ui": "npm:3.84.1"
     busboy: "npm:^1.6.0"
     dequal: "npm:2.0.3"
     file-type: "npm:21.3.4"
@@ -4738,53 +4528,53 @@ __metadata:
     path-to-regexp: "npm:6.3.0"
     qs-esm: "npm:8.0.1"
     sass: "npm:1.77.4"
-    uuid: "npm:10.0.0"
+    uuid: "npm:11.1.0"
   peerDependencies:
     graphql: ^16.8.1
-    next: ">=15.2.9 <15.3.0 || >=15.3.9 <15.4.0 || >=15.4.11 <15.5.0 || >=16.2.0-canary.10 <17.0.0"
-    payload: 3.81.0
-  checksum: 10c0/f44c326e366c25376a64823b109fc3219268cf2db9bb65a0650712cf119a2c38b08c0e4e10c910fb335c31963e0fd8022e45d446b598ce02f648ba68b51943c0
+    next: ">=15.2.9 <15.3.0 || >=15.3.9 <15.4.0 || >=15.4.11 <15.5.0 || >=16.2.2 <17.0.0"
+    payload: 3.84.1
+  checksum: 10c0/d6e8404d9f60102e1fd17b39062279293bebe98efabe7f7921c8e054ab760df5f631c43af3e520eb6c238d65646c616414d9f5544e46ef08a3d34acb7aed1b6d
   languageName: node
   linkType: hard
 
-"@payloadcms/plugin-nested-docs@npm:3.81.0":
-  version: 3.81.0
-  resolution: "@payloadcms/plugin-nested-docs@npm:3.81.0"
+"@payloadcms/plugin-nested-docs@npm:3.84.1":
+  version: 3.84.1
+  resolution: "@payloadcms/plugin-nested-docs@npm:3.84.1"
   peerDependencies:
-    payload: 3.81.0
-  checksum: 10c0/8348dfd525f5b345beecb6d1c6157e63bc314b62aee841d0ec18edcbd0886a1954dc5ac857dd2e32551e1f4c26baf9bd4ea3ac7d9b50f5fbea699b7dfc1b8bef
+    payload: 3.84.1
+  checksum: 10c0/029a9a22a1c5bcd126dc0d4e900c20687d90b7b5878fba438955763a90a321c59cc1240ec6ecbbcf46788fa0f5df936e4a1cbaa2de7d795723c87dc1e481e24a
   languageName: node
   linkType: hard
 
-"@payloadcms/plugin-redirects@npm:3.81.0":
-  version: 3.81.0
-  resolution: "@payloadcms/plugin-redirects@npm:3.81.0"
+"@payloadcms/plugin-redirects@npm:3.84.1":
+  version: 3.84.1
+  resolution: "@payloadcms/plugin-redirects@npm:3.84.1"
   dependencies:
-    "@payloadcms/translations": "npm:3.81.0"
-    payload: "npm:3.81.0"
+    "@payloadcms/translations": "npm:3.84.1"
+    payload: "npm:3.84.1"
   peerDependencies:
-    payload: 3.81.0
-  checksum: 10c0/39d09e64668b07a66dd37e7ab16a59f5fbec9c6fb06394da9eeb4b76a91aaed7c8b077cbe1d582ed4bb80235ecb69d9c68a81aa897a30bc9600bd7616691101c
+    payload: 3.84.1
+  checksum: 10c0/68874cf487e8ea56c33ed17724e2d810c61dbbd8342840a54e5c7aa90b4cc23d0759adfc64fbe43cd172c1ce3a58707fa883445278ab6e771f3b3ccaa98fba77
   languageName: node
   linkType: hard
 
-"@payloadcms/plugin-seo@npm:3.81.0":
-  version: 3.81.0
-  resolution: "@payloadcms/plugin-seo@npm:3.81.0"
+"@payloadcms/plugin-seo@npm:3.84.1":
+  version: 3.84.1
+  resolution: "@payloadcms/plugin-seo@npm:3.84.1"
   dependencies:
-    "@payloadcms/translations": "npm:3.81.0"
-    "@payloadcms/ui": "npm:3.81.0"
+    "@payloadcms/translations": "npm:3.84.1"
+    "@payloadcms/ui": "npm:3.84.1"
   peerDependencies:
-    payload: 3.81.0
+    payload: 3.84.1
     react: ^19.0.1 || ^19.1.2 || ^19.2.1
     react-dom: ^19.0.1 || ^19.1.2 || ^19.2.1
-  checksum: 10c0/5a3c66a08303df62312af5f10eeffcb7b924f9704205a6001860e3177e02e3e4b35146d7daca8f0a94dccce12f2e7fa3a61c856036d4ef25514682d1c36a6b04
+  checksum: 10c0/6619aa0e9a76d4d4f464f290f46809b5cbf514b96fe80a510ea72c64b1db0abc5b0bc5d52ae21b6eb1ba7bcac4fc12f281831532b84f089e71ce8e7c12ffd6cc
   languageName: node
   linkType: hard
 
-"@payloadcms/richtext-lexical@npm:3.81.0":
-  version: 3.81.0
-  resolution: "@payloadcms/richtext-lexical@npm:3.81.0"
+"@payloadcms/richtext-lexical@npm:3.84.1":
+  version: 3.84.1
+  resolution: "@payloadcms/richtext-lexical@npm:3.84.1"
   dependencies:
     "@lexical/clipboard": "npm:0.41.0"
     "@lexical/headless": "npm:0.41.0"
@@ -4797,9 +4587,8 @@ __metadata:
     "@lexical/selection": "npm:0.41.0"
     "@lexical/table": "npm:0.41.0"
     "@lexical/utils": "npm:0.41.0"
-    "@payloadcms/translations": "npm:3.81.0"
-    "@payloadcms/ui": "npm:3.81.0"
-    "@types/uuid": "npm:10.0.0"
+    "@payloadcms/translations": "npm:3.84.1"
+    "@payloadcms/ui": "npm:3.84.1"
     acorn: "npm:8.16.0"
     bson-objectid: "npm:2.0.4"
     csstype: "npm:3.1.3"
@@ -4813,30 +4602,30 @@ __metadata:
     qs-esm: "npm:8.0.1"
     react-error-boundary: "npm:4.1.2"
     ts-essentials: "npm:10.0.3"
-    uuid: "npm:10.0.0"
+    uuid: "npm:11.1.0"
   peerDependencies:
     "@faceless-ui/modal": 3.0.0
     "@faceless-ui/scroll-info": 2.0.0
-    "@payloadcms/next": 3.81.0
-    payload: 3.81.0
+    "@payloadcms/next": 3.84.1
+    payload: 3.84.1
     react: ^19.0.1 || ^19.1.2 || ^19.2.1
     react-dom: ^19.0.1 || ^19.1.2 || ^19.2.1
-  checksum: 10c0/4a3b1596032e7c3b01e8f8521cd47eb682a1dfd21f3541809a51da83699b39609af75795d9a5aa32c24cb31a85dbecb8caa92dd6f9415f1d8c59dcfb38988f70
+  checksum: 10c0/ccd51a9075309b97b9cdc7d58ff5940f1b8e65ef27281ba5979d505e2388182cb88a14da4ab110ce4f95bc39f437e40c4fcc1fc843c84a05a09a2ad66aab07d1
   languageName: node
   linkType: hard
 
-"@payloadcms/translations@npm:3.81.0":
-  version: 3.81.0
-  resolution: "@payloadcms/translations@npm:3.81.0"
+"@payloadcms/translations@npm:3.84.1":
+  version: 3.84.1
+  resolution: "@payloadcms/translations@npm:3.84.1"
   dependencies:
     date-fns: "npm:4.1.0"
-  checksum: 10c0/cedf4de5d063ad7694b9dfaaa1460d9cec860b3fcc31f8e5d9992832625471e026a7125fbfc2eaeaa1601ff098134841d1ab88964587afa6f84a8b58b4094fb9
+  checksum: 10c0/c3ed55df1dd04bfef22b4f58861fdbb7e650bc95c638848b3b35c719f5c8652c972bc8f62dee51171748c811b4cf130e66adda29b573d6215ae881d8f9465de1
   languageName: node
   linkType: hard
 
-"@payloadcms/ui@npm:3.81.0":
-  version: 3.81.0
-  resolution: "@payloadcms/ui@npm:3.81.0"
+"@payloadcms/ui@npm:3.84.1":
+  version: 3.84.1
+  resolution: "@payloadcms/ui@npm:3.84.1"
   dependencies:
     "@date-fns/tz": "npm:1.2.0"
     "@dnd-kit/core": "npm:6.3.1"
@@ -4846,7 +4635,7 @@ __metadata:
     "@faceless-ui/scroll-info": "npm:2.0.0"
     "@faceless-ui/window-info": "npm:3.0.1"
     "@monaco-editor/react": "npm:4.7.0"
-    "@payloadcms/translations": "npm:3.81.0"
+    "@payloadcms/translations": "npm:3.84.1"
     bson-objectid: "npm:2.0.4"
     date-fns: "npm:4.1.0"
     dequal: "npm:2.0.3"
@@ -4860,13 +4649,13 @@ __metadata:
     sonner: "npm:^1.7.2"
     ts-essentials: "npm:10.0.3"
     use-context-selector: "npm:2.0.0"
-    uuid: "npm:10.0.0"
+    uuid: "npm:11.1.0"
   peerDependencies:
-    next: ">=15.2.9 <15.3.0 || >=15.3.9 <15.4.0 || >=15.4.11 <15.5.0 || >=16.2.0-canary.10 <17.0.0"
-    payload: 3.81.0
+    next: ">=15.2.9 <15.3.0 || >=15.3.9 <15.4.0 || >=15.4.11 <15.5.0 || >=16.2.2 <17.0.0"
+    payload: 3.84.1
     react: ^19.0.1 || ^19.1.2 || ^19.2.1
     react-dom: ^19.0.1 || ^19.1.2 || ^19.2.1
-  checksum: 10c0/a67f53a5c7c962deca21d880d75ccda8c205044224796fb5fe4fabdfbc59ca046df9ddd562b3e9d620794a2445b349130267a84842e345a12199cdc798440665
+  checksum: 10c0/476b982d3f11c8d8b28767a1cb86aebe33c6b82d240b2207d3e88f62f6d500d8d2adaed9728527d2216e1f44a9e1d58bcad9ae6eafe6e9824e14d4a4680339dc
   languageName: node
   linkType: hard
 
@@ -5840,14 +5629,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/pg@npm:8.10.2":
-  version: 8.10.2
-  resolution: "@types/pg@npm:8.10.2"
+"@types/pg@npm:8.20.0":
+  version: 8.20.0
+  resolution: "@types/pg@npm:8.20.0"
   dependencies:
     "@types/node": "npm:*"
     pg-protocol: "npm:*"
-    pg-types: "npm:^4.0.1"
-  checksum: 10c0/cd75b2b7827ddbef53dd41cc9a1325c65fb7dd64cb5a703a433f9f7f9c0d4b4a0828c00bda6fa4eb301bddc469d81173dcf0187e492c36c17104a90d3e6a27fd
+    pg-types: "npm:^2.2.0"
+  checksum: 10c0/c8b5aa794ea074aa20d0c1ef6c721ce0fe16f2c084d0ccc32b7f12909a08ec969e6b01a094ce8e7019cc425381c4b59f261bd0133daf0c6d4aca5c6c492e8312
   languageName: node
   linkType: hard
 
@@ -5927,13 +5716,6 @@ __metadata:
   version: 2.0.11
   resolution: "@types/unist@npm:2.0.11"
   checksum: 10c0/24dcdf25a168f453bb70298145eb043cfdbb82472db0bc0b56d6d51cd2e484b9ed8271d4ac93000a80da568f2402e9339723db262d0869e2bf13bc58e081768d
-  languageName: node
-  linkType: hard
-
-"@types/uuid@npm:10.0.0":
-  version: 10.0.0
-  resolution: "@types/uuid@npm:10.0.0"
-  checksum: 10c0/9a1404bf287164481cb9b97f6bb638f78f955be57c40c6513b7655160beb29df6f84c915aaf4089a1559c216557dc4d2f79b48d978742d3ae10b937420ddac60
   languageName: node
   linkType: hard
 
@@ -7400,30 +7182,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
+"color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: 10c0/a1a3f914156960902f46f7f56bc62effc6c94e84b2cae157a526b1c1f74b677a47ec602bf68a61abfa2b42d15b7c5651c6dbe72a43af720bc588dff885b10f95
-  languageName: node
-  linkType: hard
-
-"color-string@npm:^1.9.0":
-  version: 1.9.1
-  resolution: "color-string@npm:1.9.1"
-  dependencies:
-    color-name: "npm:^1.0.0"
-    simple-swizzle: "npm:^0.2.2"
-  checksum: 10c0/b0bfd74c03b1f837f543898b512f5ea353f71630ccdd0d66f83028d1f0924a7d4272deb278b9aef376cacf1289b522ac3fb175e99895283645a2dc3a33af2404
-  languageName: node
-  linkType: hard
-
-"color@npm:^4.2.3":
-  version: 4.2.3
-  resolution: "color@npm:4.2.3"
-  dependencies:
-    color-convert: "npm:^2.0.1"
-    color-string: "npm:^1.9.0"
-  checksum: 10c0/7fbe7cfb811054c808349de19fb380252e5e34e61d7d168ec3353e9e9aacb1802674bddc657682e4e9730c2786592a4de6f8283e7e0d3870b829bb0b7b2f6118
   languageName: node
   linkType: hard
 
@@ -7531,10 +7293,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"croner@npm:9.1.0":
-  version: 9.1.0
-  resolution: "croner@npm:9.1.0"
-  checksum: 10c0/7debd8d171e84b2519a2adfe6a4ed6f761890da3d15239511de87f16f46ae040b1a5d89a40ad58bb89f0e4546d3a9bf093a5a65ce0484a89451d97de139ad64a
+"croner@npm:10.0.1":
+  version: 10.0.1
+  resolution: "croner@npm:10.0.1"
+  checksum: 10c0/b1a022f8c786b19799e662e0f11686937e97133e386efa2859e316ba64b7a9c2ecd0d1500cdbe3157625ff7e9af8584c7d6e41c9a17db892c731f83be464bc92
   languageName: node
   linkType: hard
 
@@ -7859,13 +7621,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-libc@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "detect-libc@npm:2.0.4"
-  checksum: 10c0/c15541f836eba4b1f521e4eecc28eefefdbc10a94d3b8cb4c507689f332cc111babb95deda66f2de050b22122113189986d5190be97d51b5a2b23b938415e67c
-  languageName: node
-  linkType: hard
-
 "detect-libc@npm:^2.1.2":
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2"
@@ -7991,9 +7746,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"drizzle-orm@npm:0.44.7":
-  version: 0.44.7
-  resolution: "drizzle-orm@npm:0.44.7"
+"drizzle-orm@npm:0.45.2":
+  version: 0.45.2
+  resolution: "drizzle-orm@npm:0.45.2"
   peerDependencies:
     "@aws-sdk/client-rds-data": ">=3"
     "@cloudflare/workers-types": ">=4"
@@ -8082,7 +7837,7 @@ __metadata:
       optional: true
     sqlite3:
       optional: true
-  checksum: 10c0/6adfe19179c83be397490c21573433e38ed7eff890bbb1c3b39157ec57d6b7420e9dcfebb8fe0e6ea534b29a53a33b2ec75c77dd2ac6b474b7055965ee7df00d
+  checksum: 10c0/deb4a0230a79b1ff8c61365808bdb06a78e9e32171625f1c61d791dec445fad5cd9bc4ce2e6175b0ff1be7fb913310b2fd07b94a2cbe8027581b7d99469b8060
   languageName: node
   linkType: hard
 
@@ -9994,13 +9749,6 @@ __metadata:
   version: 0.2.1
   resolution: "is-arrayish@npm:0.2.1"
   checksum: 10c0/e7fb686a739068bb70f860b39b67afc62acc62e36bb61c5f965768abce1873b379c563e61dd2adad96ebb7edf6651111b385e490cf508378959b0ed4cac4e729
-  languageName: node
-  linkType: hard
-
-"is-arrayish@npm:^0.3.1":
-  version: 0.3.2
-  resolution: "is-arrayish@npm:0.3.2"
-  checksum: 10c0/f59b43dc1d129edb6f0e282595e56477f98c40278a2acdc8b0a5c57097c9eff8fe55470493df5775478cf32a4dc8eaf6d3a749f07ceee5bc263a78b2434f6a54
   languageName: node
   linkType: hard
 
@@ -11942,13 +11690,13 @@ __metadata:
     "@next/third-parties": "npm:15.4.11"
     "@octokit/graphql": "npm:^9.0.3"
     "@octokit/rest": "npm:^22.0.1"
-    "@payloadcms/db-postgres": "npm:3.81.0"
-    "@payloadcms/email-nodemailer": "npm:3.81.0"
-    "@payloadcms/next": "npm:3.81.0"
-    "@payloadcms/plugin-nested-docs": "npm:3.81.0"
-    "@payloadcms/plugin-redirects": "npm:3.81.0"
-    "@payloadcms/plugin-seo": "npm:3.81.0"
-    "@payloadcms/richtext-lexical": "npm:3.81.0"
+    "@payloadcms/db-postgres": "npm:3.84.1"
+    "@payloadcms/email-nodemailer": "npm:3.84.1"
+    "@payloadcms/next": "npm:3.84.1"
+    "@payloadcms/plugin-nested-docs": "npm:3.84.1"
+    "@payloadcms/plugin-redirects": "npm:3.84.1"
+    "@payloadcms/plugin-seo": "npm:3.84.1"
+    "@payloadcms/richtext-lexical": "npm:3.84.1"
     "@react-email/components": "npm:^1.0.11"
     "@react-email/render": "npm:^2.0.5"
     "@svgr/webpack": "npm:^8.1.0"
@@ -11986,7 +11734,7 @@ __metadata:
     next: "npm:15.4.11"
     next-themes: "npm:^0.4.6"
     node-cron: "npm:^4.2.1"
-    payload: "npm:3.81.0"
+    payload: "npm:3.84.1"
     prettier: "npm:^3.8.1"
     react: "npm:19.2.4"
     react-dom: "npm:19.2.4"
@@ -12300,13 +12048,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"obuf@npm:~1.1.2":
-  version: 1.1.2
-  resolution: "obuf@npm:1.1.2"
-  checksum: 10c0/520aaac7ea701618eacf000fc96ae458e20e13b0569845800fc582f81b386731ab22d55354b4915d58171db00e79cfcd09c1638c02f89577ef092b38c65b7d81
-  languageName: node
-  linkType: hard
-
 "on-exit-leak-free@npm:^2.1.0":
   version: 2.1.2
   resolution: "on-exit-leak-free@npm:2.1.2"
@@ -12532,19 +12273,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"payload@npm:3.81.0":
-  version: 3.81.0
-  resolution: "payload@npm:3.81.0"
+"payload@npm:3.84.1":
+  version: 3.84.1
+  resolution: "payload@npm:3.84.1"
   dependencies:
     "@next/env": "npm:^15.1.5"
-    "@payloadcms/translations": "npm:3.81.0"
+    "@payloadcms/translations": "npm:3.84.1"
     "@types/busboy": "npm:1.5.4"
     ajv: "npm:8.18.0"
     bson-objectid: "npm:2.0.4"
     busboy: "npm:^1.6.0"
     ci-info: "npm:^4.1.0"
     console-table-printer: "npm:2.12.1"
-    croner: "npm:9.1.0"
+    croner: "npm:10.0.1"
     dataloader: "npm:2.2.3"
     deepmerge: "npm:4.3.1"
     file-type: "npm:21.3.4"
@@ -12565,13 +12306,13 @@ __metadata:
     ts-essentials: "npm:10.0.3"
     tsx: "npm:4.21.0"
     undici: "npm:7.24.4"
-    uuid: "npm:10.0.0"
+    uuid: "npm:11.1.0"
     ws: "npm:^8.16.0"
   peerDependencies:
     graphql: ^16.8.1
   bin:
     payload: bin.js
-  checksum: 10c0/7de8d8b1e4038f4f33becaaf071cf71e20189f8d0c921e0d50c315987c088c215148dcce656748247392a94e182b05b9e6f0f4c64904e57ec18e1b1da3d9e728
+  checksum: 10c0/b6bd648ac65d46b5c332ff983588233f163576be5e52c93a3559e1903d7c5ba4dd2181682a44b0ed84c8eee5f2e169479469041bcffc8905cf2a307319fd2088
   languageName: node
   linkType: hard
 
@@ -12582,17 +12323,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pg-cloudflare@npm:^1.2.7":
-  version: 1.2.7
-  resolution: "pg-cloudflare@npm:1.2.7"
-  checksum: 10c0/8a52713dbdecc9d389dc4e65e3b7ede2e199ec3715f7491ee80a15db171f2d75677a102e9c2cef0cb91a2f310e91f976eaec0dd6ef5d8bf357de0b948f9d9431
+"pg-cloudflare@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "pg-cloudflare@npm:1.3.0"
+  checksum: 10c0/b0866c88af8e54c7b3ed510719d92df37714b3af5e3a3a10d9f761fcec99483e222f5b78a1f2de590368127648087c45c01aaf66fadbe46edb25673eedc4f8fc
   languageName: node
   linkType: hard
 
-"pg-connection-string@npm:^2.9.1":
-  version: 2.9.1
-  resolution: "pg-connection-string@npm:2.9.1"
-  checksum: 10c0/9a646529bbc0843806fc5de98ce93735a4612b571f11867178a85665d11989a827e6fd157388ca0e34ec948098564fce836c178cfd499b9f0e8cd9972b8e2e5c
+"pg-connection-string@npm:^2.12.0":
+  version: 2.12.0
+  resolution: "pg-connection-string@npm:2.12.0"
+  checksum: 10c0/3a26c62884a9f0464718f652bd5d6bce276ebda830c0fef4de4f88ae73c2507d70cae1d45c2f5b49bebd76187fb4c94f889d07c53fca6acd06b2eecbebcdc336
   languageName: node
   linkType: hard
 
@@ -12603,19 +12344,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pg-numeric@npm:1.0.2":
-  version: 1.0.2
-  resolution: "pg-numeric@npm:1.0.2"
-  checksum: 10c0/43dd9884e7b52c79ddc28d2d282d7475fce8bba13452d33c04ceb2e0a65f561edf6699694e8e1c832ff9093770496363183c950dd29608e1bdd98f344b25bca9
-  languageName: node
-  linkType: hard
-
-"pg-pool@npm:^3.10.1":
-  version: 3.10.1
-  resolution: "pg-pool@npm:3.10.1"
+"pg-pool@npm:^3.13.0":
+  version: 3.13.0
+  resolution: "pg-pool@npm:3.13.0"
   peerDependencies:
     pg: ">=8.0"
-  checksum: 10c0/a00916b7df64226cc597fe769e3a757ff9b11562dc87ce5b0a54101a18c1fe282daaa2accaf27221e81e1e4cdf4da6a33dab09614734d32904d6c4e11c44a079
+  checksum: 10c0/2756f79cda14e3834356f2ca035deab806bca2172a38a488b62ada54bd3e65d33f583661bbe96da0c0e75e6bc59807ada733c37efca6e24ae2893429936a1549
   languageName: node
   linkType: hard
 
@@ -12626,14 +12360,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pg-protocol@npm:^1.10.3":
-  version: 1.10.3
-  resolution: "pg-protocol@npm:1.10.3"
-  checksum: 10c0/f7ef54708c93ee6d271e37678296fc5097e4337fca91a88a3d99359b78633dbdbf6e983f0adb34b7cdd261b7ec7266deb20c3233bf3dfdb498b3e1098e8750b9
+"pg-protocol@npm:^1.13.0":
+  version: 1.13.0
+  resolution: "pg-protocol@npm:1.13.0"
+  checksum: 10c0/a4e851e6bb8ff404ca19d561cf49b6b0caf45163bd3f289889edaf6c4e9fb25b08fb57f50d37a8cc86007efcf2cbb3dd2372c97a353a546f45eb49ddebc84fa9
   languageName: node
   linkType: hard
 
-"pg-types@npm:2.2.0":
+"pg-types@npm:2.2.0, pg-types@npm:^2.2.0":
   version: 2.2.0
   resolution: "pg-types@npm:2.2.0"
   dependencies:
@@ -12646,29 +12380,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pg-types@npm:^4.0.1":
-  version: 4.0.2
-  resolution: "pg-types@npm:4.0.2"
+"pg@npm:8.20.0":
+  version: 8.20.0
+  resolution: "pg@npm:8.20.0"
   dependencies:
-    pg-int8: "npm:1.0.1"
-    pg-numeric: "npm:1.0.2"
-    postgres-array: "npm:~3.0.1"
-    postgres-bytea: "npm:~3.0.0"
-    postgres-date: "npm:~2.1.0"
-    postgres-interval: "npm:^3.0.0"
-    postgres-range: "npm:^1.1.1"
-  checksum: 10c0/780fccda2f3fa2a34e85a72e8e7dadb7d88fbe71ce88f126cb3313f333ad836d02488ec4ff3d94d0c1e5846f735d6e6c6281f8059e6b8919d2180429acaec3e2
-  languageName: node
-  linkType: hard
-
-"pg@npm:8.16.3":
-  version: 8.16.3
-  resolution: "pg@npm:8.16.3"
-  dependencies:
-    pg-cloudflare: "npm:^1.2.7"
-    pg-connection-string: "npm:^2.9.1"
-    pg-pool: "npm:^3.10.1"
-    pg-protocol: "npm:^1.10.3"
+    pg-cloudflare: "npm:^1.3.0"
+    pg-connection-string: "npm:^2.12.0"
+    pg-pool: "npm:^3.13.0"
+    pg-protocol: "npm:^1.13.0"
     pg-types: "npm:2.2.0"
     pgpass: "npm:1.0.5"
   peerDependencies:
@@ -12679,7 +12398,7 @@ __metadata:
   peerDependenciesMeta:
     pg-native:
       optional: true
-  checksum: 10c0/a6a407ff0efb7599760d72ffdcda47a74c34c0fd71d896623caac45cf2cfb0f49a10973cce23110f182b9810639a1e9f6904454d7358c7001574ee0ffdcbce2a
+  checksum: 10c0/e21d44b9fb3ec188e67778d7abd32d945a546f2da5128b6c8c16da8ae1e42fdc953c0d6f0a2ee65d11f31808c1dffaf908cb9c880cd2e8f0ae05525e4b8bc832
   languageName: node
   linkType: hard
 
@@ -12846,26 +12565,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postgres-array@npm:~3.0.1":
-  version: 3.0.2
-  resolution: "postgres-array@npm:3.0.2"
-  checksum: 10c0/644aa071f67a66a59f641f8e623887d2b915bc102a32643e2aa8b54c11acd343c5ad97831ea444dd37bd4b921ba35add4aa2cb0c6b76700a8252c2324aeba5b4
-  languageName: node
-  linkType: hard
-
 "postgres-bytea@npm:~1.0.0":
   version: 1.0.0
   resolution: "postgres-bytea@npm:1.0.0"
   checksum: 10c0/febf2364b8a8953695cac159eeb94542ead5886792a9627b97e33f6b5bb6e263bc0706ab47ec221516e79fbd6b2452d668841830fb3b49ec6c0fc29be61892ce
-  languageName: node
-  linkType: hard
-
-"postgres-bytea@npm:~3.0.0":
-  version: 3.0.0
-  resolution: "postgres-bytea@npm:3.0.0"
-  dependencies:
-    obuf: "npm:~1.1.2"
-  checksum: 10c0/41c79cc48aa730c5ba3eda6ab989a940034f07a1f57b8f2777dce56f1b8cca16c5870582932b5b10cc605048aef9b6157e06253c871b4717cafc6d00f55376aa
   languageName: node
   linkType: hard
 
@@ -12876,33 +12579,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postgres-date@npm:~2.1.0":
-  version: 2.1.0
-  resolution: "postgres-date@npm:2.1.0"
-  checksum: 10c0/00a7472c10788f6b0d08d24108bf1eb80858de1bd6317740198a564918ea4a69b80c98148167b92ae688abd606483020d0de0dd3a36f3ea9a3e26bbeef3464f4
-  languageName: node
-  linkType: hard
-
 "postgres-interval@npm:^1.1.0":
   version: 1.2.0
   resolution: "postgres-interval@npm:1.2.0"
   dependencies:
     xtend: "npm:^4.0.0"
   checksum: 10c0/c1734c3cb79e7f22579af0b268a463b1fa1d084e742a02a7a290c4f041e349456f3bee3b4ee0bb3f226828597f7b76deb615c1b857db9a742c45520100456272
-  languageName: node
-  linkType: hard
-
-"postgres-interval@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "postgres-interval@npm:3.0.0"
-  checksum: 10c0/8b570b30ea37c685e26d136d34460f246f98935a1533defc4b53bb05ee23ae3dc7475b718ec7ea607a57894d8c6b4f1adf67ca9cc83a75bdacffd427d5c68de8
-  languageName: node
-  linkType: hard
-
-"postgres-range@npm:^1.1.1":
-  version: 1.1.4
-  resolution: "postgres-range@npm:1.1.4"
-  checksum: 10c0/254494ef81df208e0adeae6b66ce394aba37914ea14c7ece55a45fb6691b7db04bee74c825380a47c887a9f87158fd3d86f758f9cc60b76d3a38ce5aca7912e8
   languageName: node
   linkType: hard
 
@@ -13837,84 +13519,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sharp@npm:^0.34.3":
-  version: 0.34.3
-  resolution: "sharp@npm:0.34.3"
-  dependencies:
-    "@img/sharp-darwin-arm64": "npm:0.34.3"
-    "@img/sharp-darwin-x64": "npm:0.34.3"
-    "@img/sharp-libvips-darwin-arm64": "npm:1.2.0"
-    "@img/sharp-libvips-darwin-x64": "npm:1.2.0"
-    "@img/sharp-libvips-linux-arm": "npm:1.2.0"
-    "@img/sharp-libvips-linux-arm64": "npm:1.2.0"
-    "@img/sharp-libvips-linux-ppc64": "npm:1.2.0"
-    "@img/sharp-libvips-linux-s390x": "npm:1.2.0"
-    "@img/sharp-libvips-linux-x64": "npm:1.2.0"
-    "@img/sharp-libvips-linuxmusl-arm64": "npm:1.2.0"
-    "@img/sharp-libvips-linuxmusl-x64": "npm:1.2.0"
-    "@img/sharp-linux-arm": "npm:0.34.3"
-    "@img/sharp-linux-arm64": "npm:0.34.3"
-    "@img/sharp-linux-ppc64": "npm:0.34.3"
-    "@img/sharp-linux-s390x": "npm:0.34.3"
-    "@img/sharp-linux-x64": "npm:0.34.3"
-    "@img/sharp-linuxmusl-arm64": "npm:0.34.3"
-    "@img/sharp-linuxmusl-x64": "npm:0.34.3"
-    "@img/sharp-wasm32": "npm:0.34.3"
-    "@img/sharp-win32-arm64": "npm:0.34.3"
-    "@img/sharp-win32-ia32": "npm:0.34.3"
-    "@img/sharp-win32-x64": "npm:0.34.3"
-    color: "npm:^4.2.3"
-    detect-libc: "npm:^2.0.4"
-    semver: "npm:^7.7.2"
-  dependenciesMeta:
-    "@img/sharp-darwin-arm64":
-      optional: true
-    "@img/sharp-darwin-x64":
-      optional: true
-    "@img/sharp-libvips-darwin-arm64":
-      optional: true
-    "@img/sharp-libvips-darwin-x64":
-      optional: true
-    "@img/sharp-libvips-linux-arm":
-      optional: true
-    "@img/sharp-libvips-linux-arm64":
-      optional: true
-    "@img/sharp-libvips-linux-ppc64":
-      optional: true
-    "@img/sharp-libvips-linux-s390x":
-      optional: true
-    "@img/sharp-libvips-linux-x64":
-      optional: true
-    "@img/sharp-libvips-linuxmusl-arm64":
-      optional: true
-    "@img/sharp-libvips-linuxmusl-x64":
-      optional: true
-    "@img/sharp-linux-arm":
-      optional: true
-    "@img/sharp-linux-arm64":
-      optional: true
-    "@img/sharp-linux-ppc64":
-      optional: true
-    "@img/sharp-linux-s390x":
-      optional: true
-    "@img/sharp-linux-x64":
-      optional: true
-    "@img/sharp-linuxmusl-arm64":
-      optional: true
-    "@img/sharp-linuxmusl-x64":
-      optional: true
-    "@img/sharp-wasm32":
-      optional: true
-    "@img/sharp-win32-arm64":
-      optional: true
-    "@img/sharp-win32-ia32":
-      optional: true
-    "@img/sharp-win32-x64":
-      optional: true
-  checksum: 10c0/df9e6645e3db6ed298a0ac956ba74e468c367fc038b547936fbdddc6a29fce9af40413acbef73b3716291530760f311a20e45c8983f20ee5ea69dd2f21464a2b
-  languageName: node
-  linkType: hard
-
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
@@ -13990,15 +13594,6 @@ __metadata:
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10c0/41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
-  languageName: node
-  linkType: hard
-
-"simple-swizzle@npm:^0.2.2":
-  version: 0.2.2
-  resolution: "simple-swizzle@npm:0.2.2"
-  dependencies:
-    is-arrayish: "npm:^0.3.1"
-  checksum: 10c0/df5e4662a8c750bdba69af4e8263c5d96fe4cd0f9fe4bdfa3cbdeb45d2e869dff640beaaeb1ef0e99db4d8d2ec92f85508c269f50c972174851bc1ae5bd64308
   languageName: node
   linkType: hard
 
@@ -15234,21 +14829,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:10.0.0":
-  version: 10.0.0
-  resolution: "uuid@npm:10.0.0"
+"uuid@npm:11.1.0":
+  version: 11.1.0
+  resolution: "uuid@npm:11.1.0"
   bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/eab18c27fe4ab9fb9709a5d5f40119b45f2ec8314f8d4cf12ce27e4c6f4ffa4a6321dc7db6c515068fa373c075b49691ba969f0010bf37f44c37ca40cd6bf7fe
-  languageName: node
-  linkType: hard
-
-"uuid@npm:9.0.0":
-  version: 9.0.0
-  resolution: "uuid@npm:9.0.0"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/8867e438990d1d33ac61093e2e4e3477a2148b844e4fa9e3c2360fa4399292429c4b6ec64537eb1659c97b2d10db349c673ad58b50e2824a11e0d3630de3c056
+    uuid: dist/esm/bin/uuid
+  checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The payload bump here isn't needed for the media upload fix.

Media uploads were failing with error (on prod and local):
```
    [13:40:44] ERROR: A boolean was expected

    err: {

      "type": "TypeError",

      "message": "A boolean was expected",

      "stack":

          TypeError: A boolean was expected

              at /app/node_modules/sharp/lib/output.js:1612:15

              at new Promise (<anonymous>)

              at Sharp._pipeline (/app/node_modules/sharp/lib/output.js:1611:14)

              at Sharp.toBuffer (/app/node_modules/sharp/lib/output.js:164:15)

              at dj (/app/.next/server/chunks/8511.js:318:58899)

              at async R (/app/.next/server/chunks/8511.js:304:42526)

              at async a0 (/app/.next/server/chunks/8511.js:355:76583)

              at async q (/app/.next/server/app/(payload)/api/[...slug]/route.js:1:6204)

              at async /app/.next/server/app/(payload)/api/[...slug]/route.js:1:8853

              at async rb.do (/app/node_modules/next/dist/compiled/next-server/app-route.runtime.prod.js:5:21059)

    }

    [13:40:44] ERROR: There was a problem while uploading the file.

    err: {

      "type": "g",

      "message": "There was a problem while uploading the file.",

      "stack":

          g: There was a problem while uploading the file.

              at dj (/app/.next/server/chunks/8511.js:318:61056)

              at async R (/app/.next/server/chunks/8511.js:304:42526)

              at async a0 (/app/.next/server/chunks/8511.js:355:76583)

              at async q (/app/.next/server/app/(payload)/api/[...slug]/route.js:1:6204)

              at async /app/.next/server/app/(payload)/api/[...slug]/route.js:1:8853

              at async rb.do (/app/node_modules/next/dist/compiled/next-server/app-route.runtime.prod.js:5:21059)

              at async rb.handle (/app/node_modules/next/dist/compiled/next-server/app-route.runtime.prod.js:5:25902)

              at async k (/app/.next/server/app/(payload)/api/[...slug]/route.js:1:12917)

              at async rb.handleResponse (/app/node_modules/next/dist/compiled/next-server/app-route.runtime.prod.js:1:104365)

              at async g (/app/.next/server/app/(payload)/api/[...slug]/route.js:1:13920)

      "data": null,

      "isOperational": true,

      "isPublic": true,

      "status": 400,

      "name": "g"

    }
```

It seems like my Payload media collection sharp config was failing to be parsed (unchanged for long time):

```
  upload: {
    mimeTypes: ['image/*', 'video/*', 'audio/*'],
    // Use webp as preferred format for all media
    formatOptions: {
      format: 'webp',
      options: {
        lossless: true,
        effort: 6,
      },
    },
    // Upload to a public directory in Next.js making them publicly accessible even outside of Payload
    staticDir: path.resolve('public/uploads/media'),
  },
```


Culprit (as also mentioned on https://github.com/lovell/sharp/issues/4388) was that Sharp was resolving to multiple verisons.
Locally I saw:
```
  ❯ yarn why sharp
  ├─ mobeigi-com-app@workspace:.
  │  └─ sharp@npm:0.34.5 (via npm:0.34.5)
  │
  ├─ next@npm:15.4.11
  │  └─ sharp@npm:0.34.3 (via npm:^0.34.3)
  │
  └─ next@npm:15.4.11 [52d1f]
     └─ sharp@npm:0.34.3 (via npm:^0.34.3)
```

Solution was to resolve to right sharp version (long term maybe update Next.js to version that uses latest sharp version too):

```
  "resolutions": {
    "sharp": "0.34.5"
  },
```

This resolved the issue and I could upload to media collection using Sharp again.