### PR TITLE
Add data-scroll-behaviour smooth to HTML element

### DIFF
--- a/app/src/app/(frontend)/layout.tsx
+++ b/app/src/app/(frontend)/layout.tsx
@@ -71,7 +71,7 @@ const RootLayout = ({
 }>) => {
   return (
     // suppressHydrationWarning needed for next-themes
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" data-scroll-behavior="smooth" suppressHydrationWarning>
       <body className={roboto.className}>
         <StyledComponentsRegistry>
           <ThemeProvider enableSystem={true} defaultTheme="system">


### PR DESCRIPTION
Error on dev:
```
[browser] Detected `scroll-behavior: smooth` on the `<html>` element. To disable smooth scrolling during route transitions, add `data-scroll-behavior="smooth"` to your <html> element. Learn more: https://nextjs.org/docs/messages/missing-data-scroll-behavior
```

This change prevents smooth scrolling from happening when you click on a link (that triggers SPA transition). However, clicking back/forward in browser will still do the scrolling to last viewed point. 

This appears to be best practice.